### PR TITLE
hotfix: leaving lobby also logged out the player from his account

### DIFF
--- a/core/src/main/java/io/github/broskipoker/ui/LobbyPanel.java
+++ b/core/src/main/java/io/github/broskipoker/ui/LobbyPanel.java
@@ -113,7 +113,8 @@ public class LobbyPanel extends Dialog {
             public void changed(ChangeEvent event, Actor actor) {
                 if (onLeaveGame != null) onLeaveGame.run();
                 if (clientConnection != null) {
-                    clientConnection.disconnect();
+                    // Use leaveTable instead of disconnect to keep the connection alive
+                    clientConnection.leaveTable();
                 }
                 hide();
             }


### PR DESCRIPTION
This pull request updates the `LobbyPanel` class to improve how the client handles leaving a game. Specifically, it replaces a direct disconnection with a method that maintains the connection while leaving the game.

### Changes to client connection handling:
* [`core/src/main/java/io/github/broskipoker/ui/LobbyPanel.java`](diffhunk://#diff-06165a70332e508098ccb7aee076dc0dced8cca0f5f4e04bfd56b4186a016bfdL116-R117): Replaced `clientConnection.disconnect()` with `clientConnection.leaveTable()` in the `changed` method to ensure the connection remains active when leaving a lobby. A comment was added to clarify this change.